### PR TITLE
Only run hard drive tests when hard drive is present

### DIFF
--- a/os/kernel/src/boot.rs
+++ b/os/kernel/src/boot.rs
@@ -16,6 +16,7 @@ use crate::interrupt::interrupt_dispatcher;
 use crate::memory::nvmem::Nfit;
 use crate::memory::pages::page_table_index;
 use crate::memory::{MemorySpace, PAGE_SIZE, nvmem};
+use crate::storage::block_device;
 use crate::network::rtl8139;
 use crate::process::thread::Thread;
 use crate::syscall::syscall_dispatcher;
@@ -259,28 +260,32 @@ pub extern "C" fn start(multiboot2_magic: u32, multiboot2_addr: *const BootInfor
     // Initialize network stack
     network::init();
 
-    let drive = storage::block_device("ata0").unwrap();
-    let mut buffer = [0; 8192];
+    match block_device("ata0") {
+        Some(drive) => {
+            let mut buffer = [0; 8192];
+            
+            // Fill buffer with some data
+            for i in 0..8192 {
+                buffer[i] = i as u8;
+            }
+            // Write data to the third sector of the drive
+            drive.write(3, 16, &mut buffer);
 
-    // Fill buffer with some data
-    for i in 0..8192 {
-        buffer[i] = i as u8;
-    }
-    // Write data to the third sector of the drive
-    drive.write(3, 16, &mut buffer);
+            // Fill buffer with zeroes
+            for i in 0..8192 {
+                buffer[i] = 0;
+            }
+            // Read data from the third sector of the drive
+            drive.read(3, 16, &mut buffer);
 
-    // Fill buffer with zeroes
-    for i in 0..8192 {
-        buffer[i] = 0;
-    }
-    // Read data from the third sector of the drive
-    drive.read(3, 16, &mut buffer);
-
-    // Check integrity of read data
-    for i in 0..8192 {
-        if buffer[i] != (i as u8) {
-            panic!("Data integrity check failed!");
-        }
+            // Check integrity of read data
+            for i in 0..8192 {
+                if buffer[i] != (i as u8) {
+                    panic!("Data integrity check failed!");
+                }
+            }
+        },
+        None => info!("No ata0 drive found, skipping drive tests."),
     }
 
     // Set up network interface for emulated QEMU network (IP: 10.0.2.15, Gateway: 10.0.2.2)


### PR DESCRIPTION
The hard drive tests introduced in b5255704ebb19ccce6a9fcc9516abb0d66f74dcd in `boot.rs` cause the boot to fail with "Panic: Called `Option::unwrap` on a `None` value" on real hardware, if the hard drive is named differently or missing at all. I think, a missing hard drive should not prevent a successful boot. Therefore, I wrapped the hard drive tests in `boot.rs` in a match statement on the hard drive detection.