### PR TITLE
Update display when deleting terminal characters (backspace key)

### DIFF
--- a/os/kernel/src/device/lfb_terminal.rs
+++ b/os/kernel/src/device/lfb_terminal.rs
@@ -228,20 +228,31 @@ impl LFBTerminal {
 
             cursor.pos.0 = 0;
             cursor.pos.1 += 1;
-        } else if c == 0x08 as char {
+        } else if c == 0x08 as char { // backspace key
+            // Store old cursor position and character before moving it one position left
             let old_pos = cursor.pos;
             let old_index = (old_pos.1 * display.size.0 + old_pos.0) as usize;
             let old_char_value = match display.char_buffer[old_index].value {
                 '\0' => ' ',
                 value => value,
             };
+            
+            // Create new character to overwrite the character to the left of the cursor
             let new_char = Character { value: ' ', fg_color: color.fg_color, bg_color: color.bg_color };
             
+            // Move the cursor one position to the left
             cursor.pos.0 -= 1;
             let new_index = (cursor.pos.1 * display.size.0 + cursor.pos.0) as usize;
             
-            display.char_buffer[new_index] = new_char;
+            display.char_buffer[new_index] = new_char; // Remove character at the new location from the character buffer
+            
+            /* Restore character display at the old cursor position before moving.
+             * This is required, as the cursor might have been blinking before moving,
+             * leaving a filled rectangle at the old position.
+             */
             LFBTerminal::print_char_at(&mut display, &mut color, old_char_value, old_pos);
+            
+            // Remove character at the new position from the screen
             LFBTerminal::print_char_at(&mut display, &mut color, new_char.value, cursor.pos);
         } else {
             let char_width = LFBTerminal::print_char_at(&mut display, &mut color, c, cursor.pos);


### PR DESCRIPTION
The backspace key was only working partially: Characters were removed from the input buffer, but the display was not updated. This commit adds display updates when using the backspace key on the terminal, updating the display when characters are deleted.