### PR TITLE
Move kernel to 25 MB

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,7 +2,7 @@
 BOOTLOADER_DIRECTORY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/loader"
 INITRD_DIRECTORY = "${BOOTLOADER_DIRECTORY}/initrd"
 OVMF_URL = "https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF.fd"
-TOWBOOT_VERSION = "0.9.1"
+TOWBOOT_VERSION = "0.9.4"
 TOWBOOT_URL = "https://github.com/hhuOS/towboot/releases/download/v${TOWBOOT_VERSION}/towbootctl-v${TOWBOOT_VERSION}"
 TAR = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "tar", mapping = { "macos" = "gtar" } }
 LINKER = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "ld", mapping = { "macos" = "x86_64-elf-ld" } }

--- a/os/kernel/link.ld
+++ b/os/kernel/link.ld
@@ -1,7 +1,17 @@
 ENTRY(start)
 
 SECTIONS {
-    . = 1M;   /* load kernel at 1 MiB */
+    /*
+     * load the kernel to the following address
+     *
+     * a QEMU VM with OVMF roughly has the following memory layout:
+     *   0KB to 640KB: free
+     * 640KB to 1MB:   devices
+     *   1MB to 8MB:   free
+     *   8MB to 9MB:   ACPI
+     *   9MB to 24MB:  Boot Services
+     */
+    . = 25M;
 
     ___KERNEL_DATA_START__ = .;
 


### PR DESCRIPTION
On QEMU, there is some ACPI memory at around 8 MB, so a kernel bigger than 7 MB wouldn't fit.

I tested this on QEMU and on the Optiplex.