### PR TITLE
Feature: dump page tables

### DIFF
--- a/os/kernel/src/boot.rs
+++ b/os/kernel/src/boot.rs
@@ -110,6 +110,7 @@ pub extern "C" fn start(multiboot2_magic: u32, multiboot2_addr: *const BootInfor
     // Create kernel process (and initialize virtual memory management)
     info!("Create kernel process and initialize paging");
     let kernel_process = process_manager().write().create_kernel_process(kernel_image_region, heap_region);
+    kernel_process.virtual_address_space.page_tables().dump();
     kernel_process.virtual_address_space.load_address_space();
 
     // Initialize serial port and enable serial logging

--- a/os/kernel/src/memory/pages.rs
+++ b/os/kernel/src/memory/pages.rs
@@ -192,13 +192,7 @@ impl Paging {
                 entry_address = base_address + (index << 12);
                 
                 if !entry.is_unused() {
-                    if entry_address == entry.addr().as_u64() as usize {
-                        // This entry is an identity mapping
-                        area.check_and_set(PageTableAreaType::Identity, entry_address);
-                    } else {
-                        area.check(entry_address);
-                        debug!("0x{:x} -> 0x{:x}", entry_address, entry.addr());
-                    }
+                    area.check_and_set(PageTableAreaType::Offset(entry_address as u64 - entry.addr().as_u64()), entry_address);
                 } else {
                     area.check_and_set(PageTableAreaType::Empty, entry_address);
                 }
@@ -507,7 +501,7 @@ impl fmt::Debug for PageTableEntryAddress {
 #[derive(Debug, PartialEq)]
 enum PageTableAreaType {
     Empty,
-    Identity,
+    Offset(u64),
 }
 
 struct PageTableArea {

--- a/os/kernel/src/memory/pages.rs
+++ b/os/kernel/src/memory/pages.rs
@@ -200,7 +200,7 @@ impl Paging {
                         debug!("0x{:x} -> 0x{:x}", entry_address, entry.addr());
                     }
                 } else {
-                    area.check(entry_address);
+                    area.check_and_set(PageTableAreaType::Empty, entry_address);
                 }
             }
             

--- a/os/kernel/src/memory/pages.rs
+++ b/os/kernel/src/memory/pages.rs
@@ -470,6 +470,9 @@ impl Paging {
     }
 }
 
+// Data structures for printing and dumping page tables
+
+/// A struct for storing the address of a page table entry, allowing to pretty-print the position of this page table entry in the page table tree (e.g. 1.2.5.2 = 2nd entry in the fifth level-three page of the second level-two page of the first level-one page)
 pub struct PageTableEntryAddress {
     address: usize,
     level: usize
@@ -498,17 +501,20 @@ impl fmt::Debug for PageTableEntryAddress {
     }
 }
 
+/// Enum to store whether an area of continuous page table entries is either empty or a linear mapping with a given offset
 #[derive(Debug, PartialEq)]
 enum PageTableAreaType {
     Empty,
     Offset(u64),
 }
 
+/// Struct to store the type and the start of an area of continuous page table entries of the same type
 struct PageTableArea {
     area_type: Option<PageTableAreaType>,
     start_address: usize
 }
 
+/// Functions to actually dump the page table by printing the size and start and end addresses of continous page table areas whenever the area type changes (e.g. an identity mapping ends and the following page table entries are empty)
 impl PageTableArea {
     pub fn new(area_type: Option<PageTableAreaType>, start_address: usize) -> Self {
         PageTableArea { area_type, start_address }


### PR DESCRIPTION
While debugging separate address spaces for kernel and user mode, I needed a simple method for dumping page tables. So I implemented Paging::dump(), which walks across the page table structure recursively. To reduce the amount of output to a minimum, it detects continuous areas in the page tables that are either empty or a linear mapping with a constant offset (identity mapping being a special case of this with offset=0). For example, for the kernel process, this results in only two output lines:

```
[0.000][INF][boot.rs] Create kernel process and initialize paging
[0.000][INF][vmm.rs] VMAs of process [1]
[0.000][INF][vmm.rs] (VirtAddr(0x100000), VMA: Space: Kernel, Type: Heap, [0x100000; 0x500000], #pages: 1024, tag: "heap------------")
[0.000][INF][vmm.rs] (VirtAddr(0x1900000), VMA: Space: Kernel, Type: Code, [0x1900000; 0x1fc9000], #pages: 1737, tag: "code------------")
[0.000][INF][process_manager.rs] Kernel process [1]: created
[0.000][DBG][pages.rs] Dumping page tables
[0.000][INF][pages.rs] Offset(0) mapping for addresses 0x0 - 0xfef3fff, PageTableEntry 0.0.0.0 - PageTableEntry 0.0.127.243
[0.000][INF][pages.rs] Empty mapping for addresses 0xfef4000 - 0xffffffffffff, PageTableEntry 0.0.127.244 - PageTableEntry 511.511.511.511
```

I've put some thought into this one, so I hope this will not only be useful for me but also for others when working with virtual memory.