### PR TITLE
Allow applications to use the network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ members = [
     "os/application/ls",
     "os/application/heaptest",
     "os/application/threadtest",
-    "os/application/ntest"
+    "os/application/ntest",
+    "os/application/nc",
 ]
 
 # [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "os/application/threadtest",
     "os/application/ntest",
     "os/application/nc",
+    "os/application/ping",
 ]
 
 # [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "os/application/ntest",
     "os/application/nc",
     "os/application/ping",
+    "os/application/ip",
 ]
 
 # [profile.release]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,7 +121,7 @@ condition = { files_not_exist = [ "${INITRD_DIRECTORY}" ] }
 [tasks.initrd]
 cwd = "${INITRD_DIRECTORY}"
 command = "${TAR}"
-args = [ "-cf", "${BOOTLOADER_DIRECTORY}/initrd.tar", "about", "hello", "helloc", "shell", "uptime", "date", "ntest", "heaptest", "threadtest", "ls" ]
+args = [ "-cf", "${BOOTLOADER_DIRECTORY}/initrd.tar", "about", "hello", "helloc", "shell", "uptime", "date", "ntest", "heaptest", "threadtest", "ls", "nc" ]
 dependencies = [ "link-members" ]
 condition = { files_modified = { input = [ "${INITRD_DIRECTORY}/*" ], output = [ "${BOOTLOADER_DIRECTORY}/initrd.tar" ] } }
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,7 +121,7 @@ condition = { files_not_exist = [ "${INITRD_DIRECTORY}" ] }
 [tasks.initrd]
 cwd = "${INITRD_DIRECTORY}"
 command = "${TAR}"
-args = [ "-cf", "${BOOTLOADER_DIRECTORY}/initrd.tar", "about", "hello", "helloc", "shell", "uptime", "date", "ntest", "heaptest", "threadtest", "ls", "nc" ]
+args = [ "-cf", "${BOOTLOADER_DIRECTORY}/initrd.tar", "about", "hello", "helloc", "shell", "uptime", "date", "ntest", "heaptest", "threadtest", "ls", "nc", "ping" ]
 dependencies = [ "link-members" ]
 condition = { files_modified = { input = [ "${INITRD_DIRECTORY}/*" ], output = [ "${BOOTLOADER_DIRECTORY}/initrd.tar" ] } }
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -44,7 +44,7 @@ args = [
     "-object", "memory-backend-file,id=mem1,share=on,mem-path=nvdimm0,size=16M",
 
     # Network configuration
-    "-nic", "model=rtl8139,id=rtl8139,hostfwd=udp::1797-:1797",
+    "-nic", "model=rtl8139,id=rtl8139,hostfwd=udp::1797-:1797,hostfwd=tcp::1797-:1797",
     "-object", "filter-dump,id=filter1,netdev=rtl8139,file=rtl8139.dump",
 
     # Audio configuration (Using pulse audio for Linux)
@@ -78,7 +78,7 @@ args = [
     "-object", "memory-backend-file,id=mem1,share=on,mem-path=nvdimm0,size=16M",
 
     # Network configuration
-    "-nic", "model=rtl8139,id=rtl8139,hostfwd=udp::1797-:1797",
+    "-nic", "model=rtl8139,id=rtl8139,hostfwd=udp::1797-:1797,hostfwd=tcp::1797-:1797",
     "-object", "filter-dump,id=filter1,netdev=rtl8139,file=rtl8139.dump",
 
     # Audio configuration (Using pulse audio for Linux)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,7 +121,7 @@ condition = { files_not_exist = [ "${INITRD_DIRECTORY}" ] }
 [tasks.initrd]
 cwd = "${INITRD_DIRECTORY}"
 command = "${TAR}"
-args = [ "-cf", "${BOOTLOADER_DIRECTORY}/initrd.tar", "about", "hello", "helloc", "shell", "uptime", "date", "ntest", "heaptest", "threadtest", "ls", "nc", "ping" ]
+args = [ "-cf", "${BOOTLOADER_DIRECTORY}/initrd.tar", "about", "hello", "helloc", "shell", "uptime", "date", "ntest", "heaptest", "threadtest", "ls", "nc", "ping", "ip" ]
 dependencies = [ "link-members" ]
 condition = { files_modified = { input = [ "${INITRD_DIRECTORY}/*" ], output = [ "${BOOTLOADER_DIRECTORY}/initrd.tar" ] } }
 

--- a/os/application/ip/Cargo.toml
+++ b/os/application/ip/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ip"
+version = "0.1.0"
+edition = "2024"
+authors = ["Niklas Sombert <niklas.sombert@uni-duesseldorf.de"]
+
+[lib]
+crate-type = ["staticlib"]
+path = "src/ip.rs"
+
+[dependencies]
+# Local dependencies
+runtime = { path = "../../library/runtime" }
+network = { path = "../../library/network" }
+terminal = { path = "../../library/terminal" }

--- a/os/application/ip/Makefile.toml
+++ b/os/application/ip/Makefile.toml
@@ -1,0 +1,64 @@
+[config]
+skip_core_tasks = true
+skip_git_env_info = true
+skip_rust_env_info = true
+skip_crate_env_info = true
+
+[env.development]
+CARGO_CFG_TARGET_FAMILY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/d3os_application.json"
+BUILD_DIRECTORY = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/d3os_application/debug"
+CARGO_BUILD_OPTION = "--lib"
+
+[env.production]
+CARGO_CFG_TARGET_FAMILY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/d3os_application.json"
+BUILD_DIRECTORY = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/d3os_application/release"
+CARGO_BUILD_OPTION = "--release"
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+RUST_TARGET_PATH = "${CARGO_MAKE_WORKING_DIRECTORY}"
+SOURCE_DIRECTORY = "${CARGO_MAKE_WORKING_DIRECTORY}/src"
+LIBRARY_DIRECTORY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/os/library"
+LINKER_FILE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/os/application/link.ld"
+RUST_OBJECT = "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}.a"
+APPLICATION = "${INITRD_DIRECTORY}/${CARGO_MAKE_PROJECT_NAME}"
+
+# Build tasks
+
+[tasks.default]
+alias = "link"
+
+[tasks.compile]
+command = "cargo"
+args = [ "build", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+condition = { files_modified = { input = [
+    "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml", "${SOURCE_DIRECTORY}/**/*.rs",
+    "${LIBRARY_DIRECTORY}/runtime/Cargo.toml", "${LIBRARY_DIRECTORY}/runtime/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/terminal/Cargo.toml", "${LIBRARY_DIRECTORY}/terminal/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/network/Cargo.toml", "${LIBRARY_DIRECTORY}/network/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/syscall/Cargo.toml", "${LIBRARY_DIRECTORY}/syscall/src/**/*.rs" ], output = [ "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}*" ] } }
+
+[tasks.link]
+command = "${LINKER}"
+args = [ "-n", "-T", "${LINKER_FILE}", "-o", "${APPLICATION}", "${RUST_OBJECT}" ]
+dependencies = [ "compile" ]
+condition = { files_modified = { input = [ "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}*", "${LINKER_FILE}" ], output = [ "${BOOTLOADER_DIRECTORY}/initrd/${CARGO_MAKE_PROJECT_NAME}" ] } }
+
+[tasks.check]
+command = "cargo"
+args = [ "check", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+
+[tasks.clippy]
+command = "cargo"
+args = [ "clippy", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+
+# Cleanup tasks
+
+[tasks.clean]
+command = "cargo"
+args = [ "clean" ]
+dependencies = [ "remove-application" ]
+
+[tasks.remove-application]
+command = "rm"
+args = [ "-f", "${APPLICATION}" ]

--- a/os/application/ip/src/ip.rs
+++ b/os/application/ip/src/ip.rs
@@ -1,0 +1,18 @@
+//! ip – show the current IP address
+
+#![no_std]
+extern crate alloc;
+
+#[allow(unused_imports)]
+use runtime::*;
+use network::get_ip_addresses;
+use terminal::{print, println};
+
+#[unsafe(no_mangle)]
+fn main() {
+    // ignore all args for now
+
+    for ip in get_ip_addresses() {
+        println!("{}", ip)
+    }
+}

--- a/os/application/nc/Cargo.toml
+++ b/os/application/nc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nc"
+version = "0.1.0"
+edition = "2024"
+authors = ["Niklas Sombert <niklas.sombert@uni-duesseldorf.de"]
+
+[lib]
+crate-type = ["staticlib"]
+path = "src/nc.rs"
+
+[dependencies]
+# Local dependencies
+runtime = { path = "../../library/runtime" }
+network = { path = "../../library/network" }
+terminal = { path = "../../library/terminal" }

--- a/os/application/nc/Makefile.toml
+++ b/os/application/nc/Makefile.toml
@@ -1,0 +1,64 @@
+[config]
+skip_core_tasks = true
+skip_git_env_info = true
+skip_rust_env_info = true
+skip_crate_env_info = true
+
+[env.development]
+CARGO_CFG_TARGET_FAMILY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/d3os_application.json"
+BUILD_DIRECTORY = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/d3os_application/debug"
+CARGO_BUILD_OPTION = "--lib"
+
+[env.production]
+CARGO_CFG_TARGET_FAMILY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/d3os_application.json"
+BUILD_DIRECTORY = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/d3os_application/release"
+CARGO_BUILD_OPTION = "--release"
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+RUST_TARGET_PATH = "${CARGO_MAKE_WORKING_DIRECTORY}"
+SOURCE_DIRECTORY = "${CARGO_MAKE_WORKING_DIRECTORY}/src"
+LIBRARY_DIRECTORY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/os/library"
+LINKER_FILE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/os/application/link.ld"
+RUST_OBJECT = "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}.a"
+APPLICATION = "${INITRD_DIRECTORY}/${CARGO_MAKE_PROJECT_NAME}"
+
+# Build tasks
+
+[tasks.default]
+alias = "link"
+
+[tasks.compile]
+command = "cargo"
+args = [ "build", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+condition = { files_modified = { input = [
+    "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml", "${SOURCE_DIRECTORY}/**/*.rs",
+    "${LIBRARY_DIRECTORY}/runtime/Cargo.toml", "${LIBRARY_DIRECTORY}/runtime/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/terminal/Cargo.toml", "${LIBRARY_DIRECTORY}/terminal/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/network/Cargo.toml", "${LIBRARY_DIRECTORY}/network/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/syscall/Cargo.toml", "${LIBRARY_DIRECTORY}/syscall/src/**/*.rs" ], output = [ "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}*" ] } }
+
+[tasks.link]
+command = "${LINKER}"
+args = [ "-n", "-T", "${LINKER_FILE}", "-o", "${APPLICATION}", "${RUST_OBJECT}" ]
+dependencies = [ "compile" ]
+condition = { files_modified = { input = [ "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}*", "${LINKER_FILE}" ], output = [ "${BOOTLOADER_DIRECTORY}/initrd/${CARGO_MAKE_PROJECT_NAME}" ] } }
+
+[tasks.check]
+command = "cargo"
+args = [ "check", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+
+[tasks.clippy]
+command = "cargo"
+args = [ "clippy", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+
+# Cleanup tasks
+
+[tasks.clean]
+command = "cargo"
+args = [ "clean" ]
+dependencies = [ "remove-application" ]
+
+[tasks.remove-application]
+command = "rm"
+args = [ "-f", "${APPLICATION}" ]

--- a/os/application/nc/src/nc.rs
+++ b/os/application/nc/src/nc.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use core::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 use alloc::string::String;
-use network::{TcpListener, TcpStream, UdpSocket};
+use network::{resolve_hostname, TcpListener, TcpStream, UdpSocket};
 #[allow(unused_imports)]
 use runtime::*;
 use terminal::{print, println, read::read};
@@ -40,8 +40,8 @@ fn main() {
     nc [-u] [-l] host port
 
 Examples:
-    nc 1.2.3.4 5678
-        open a TCP connection to 1.2.3.4:5678
+    nc example.net 5678
+        open a TCP connection to example.net:5678
     nc -u -l 0.0.0.0 1234
         bind to 0.0.0.0:1234, UDP");
                 return;
@@ -67,8 +67,8 @@ Examples:
     // for listen, this is the address and port to bind to
     // for connect, this is the remote host to connect to
     let addr = if let Some(host) = args.next() && let Some(port_str) = args.next() {
-        // TODO: also support host names
-        let ip: IpAddr = host.parse().expect("failed to parse IP address");
+        // just take the first IP address
+        let ip = resolve_hostname(&host).into_iter().next().unwrap();
         let port: u16 = port_str.parse().expect("failed to parse port");
         SocketAddr::new(ip, port)
     } else {

--- a/os/application/nc/src/nc.rs
+++ b/os/application/nc/src/nc.rs
@@ -1,7 +1,7 @@
 #![no_std]
 extern crate alloc;
 
-use core::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use core::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 use alloc::string::String;
 use network::{TcpListener, TcpStream, UdpSocket};
@@ -88,8 +88,7 @@ Examples:
         },
         Mode::Connect => match protocol {
             Protocol::Udp => {
-                // TODO: randomize this, but probably in the kernel?
-                let local_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 1797));
+                let local_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
                 Socket::Udp(UdpSocket::bind(local_addr).expect("failed to open socket"))
             },
             Protocol::Tcp => Socket::Tcp(TcpStream::connect(addr).expect("failed to open socket")),

--- a/os/application/nc/src/nc.rs
+++ b/os/application/nc/src/nc.rs
@@ -1,0 +1,46 @@
+#![no_std]
+extern crate alloc;
+
+use core::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use network::UdpSocket;
+#[allow(unused_imports)]
+use runtime::*;
+use terminal::{print, println, read::read};
+
+// TODO: also support TCP
+
+#[unsafe(no_mangle)]
+fn main() {
+    let mut args = env::args();
+    // the first argument is the program name, ignore it
+    args.next();
+    // the next arguments should be host and port
+    if let Some(host) = args.next() && let Some(port_str) = args.next() {
+        // TODO: also support host names
+        let remote_ip: IpAddr = host.parse().expect("failed to parse IP address");
+        let remote_port: u16 = port_str.parse().expect("failed to parse port");
+        let remote_addr = SocketAddr::new(remote_ip, remote_port);
+        // TODO: this can be any port
+        let local_port = remote_port;
+        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), local_port);
+        let socket = UdpSocket::bind(local_addr).expect("failed to open socket");
+        let mut buf = [0u8; 1024];
+        loop {
+            let key = read();
+            if let Some(key) = key {
+                let string = key.encode_utf8(&mut buf);
+                socket.send_to(string.as_bytes(), remote_addr)
+                    .expect("failed to send char");
+            }
+            let (len, _) = socket.recv_from(&mut buf)
+                .expect("failed to receive char");
+            if len > 0 {
+                let text = str::from_utf8(&buf[0..len]).expect("failed to parse received string");
+                print!("{text}");
+            }
+        }
+    } else {
+        println!("Usage: nc <host> <port>");
+    }
+}

--- a/os/application/ping/Cargo.toml
+++ b/os/application/ping/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ping"
+version = "0.1.0"
+edition = "2024"
+authors = ["Niklas Sombert <niklas.sombert@uni-duesseldorf.de"]
+
+[lib]
+crate-type = ["staticlib"]
+path = "src/ping.rs"
+
+[dependencies]
+smoltcp = { version = "0.12", default-features = false, features = ["proto-ipv4"] }
+# Local dependencies
+runtime = { path = "../../library/runtime" }
+concurrent = { path = "../../library/concurrent" }
+time = { path = "../../library/time" }
+network = { path = "../../library/network" }
+terminal = { path = "../../library/terminal" }

--- a/os/application/ping/Makefile.toml
+++ b/os/application/ping/Makefile.toml
@@ -1,0 +1,66 @@
+[config]
+skip_core_tasks = true
+skip_git_env_info = true
+skip_rust_env_info = true
+skip_crate_env_info = true
+
+[env.development]
+CARGO_CFG_TARGET_FAMILY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/d3os_application.json"
+BUILD_DIRECTORY = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/d3os_application/debug"
+CARGO_BUILD_OPTION = "--lib"
+
+[env.production]
+CARGO_CFG_TARGET_FAMILY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/d3os_application.json"
+BUILD_DIRECTORY = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}/d3os_application/release"
+CARGO_BUILD_OPTION = "--release"
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+RUST_TARGET_PATH = "${CARGO_MAKE_WORKING_DIRECTORY}"
+SOURCE_DIRECTORY = "${CARGO_MAKE_WORKING_DIRECTORY}/src"
+LIBRARY_DIRECTORY = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/os/library"
+LINKER_FILE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/os/application/link.ld"
+RUST_OBJECT = "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}.a"
+APPLICATION = "${INITRD_DIRECTORY}/${CARGO_MAKE_PROJECT_NAME}"
+
+# Build tasks
+
+[tasks.default]
+alias = "link"
+
+[tasks.compile]
+command = "cargo"
+args = [ "build", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+condition = { files_modified = { input = [
+    "${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml", "${SOURCE_DIRECTORY}/**/*.rs",
+    "${LIBRARY_DIRECTORY}/runtime/Cargo.toml", "${LIBRARY_DIRECTORY}/runtime/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/concurrent/Cargo.toml", "${LIBRARY_DIRECTORY}/concurrent/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/time/Cargo.toml", "${LIBRARY_DIRECTORY}/time/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/terminal/Cargo.toml", "${LIBRARY_DIRECTORY}/terminal/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/network/Cargo.toml", "${LIBRARY_DIRECTORY}/network/src/**/*.rs",
+    "${LIBRARY_DIRECTORY}/syscall/Cargo.toml", "${LIBRARY_DIRECTORY}/syscall/src/**/*.rs" ], output = [ "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}*" ] } }
+
+[tasks.link]
+command = "${LINKER}"
+args = [ "-n", "-T", "${LINKER_FILE}", "-o", "${APPLICATION}", "${RUST_OBJECT}" ]
+dependencies = [ "compile" ]
+condition = { files_modified = { input = [ "${BUILD_DIRECTORY}/lib${CARGO_MAKE_PROJECT_NAME}*", "${LINKER_FILE}" ], output = [ "${BOOTLOADER_DIRECTORY}/initrd/${CARGO_MAKE_PROJECT_NAME}" ] } }
+
+[tasks.check]
+command = "cargo"
+args = [ "check", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+
+[tasks.clippy]
+command = "cargo"
+args = [ "clippy", "-Z", "build-std=core,alloc", "-Z", "build-std-features=compiler-builtins-mem", "--target", "${CARGO_CFG_TARGET_FAMILY}", "${CARGO_BUILD_OPTION}" ]
+
+# Cleanup tasks
+
+[tasks.clean]
+command = "cargo"
+args = [ "clean" ]
+dependencies = [ "remove-application" ]
+
+[tasks.remove-application]
+command = "rm"
+args = [ "-f", "${APPLICATION}" ]

--- a/os/application/ping/src/ping.rs
+++ b/os/application/ping/src/ping.rs
@@ -1,0 +1,85 @@
+//! ping – send and receive ICMP echo requests
+//! 
+//! This is based on the [smoltcp echo example](https://github.com/smoltcp-rs/smoltcp/blob/main/examples/ping.rs).
+#![no_std]
+extern crate alloc;
+
+use core::net::IpAddr;
+
+use alloc::{string::String, vec};
+use concurrent::thread::sleep;
+use network::IcmpSocket;
+#[allow(unused_imports)]
+use runtime::*;
+use smoltcp::{phy::ChecksumCapabilities, wire::{Icmpv4Packet, Icmpv4Repr}};
+use terminal::{print, println};
+
+#[unsafe(no_mangle)]
+fn main() {
+    let mut args = env::args().peekable();
+    // the first argument is the program name, ignore it
+    args.next();
+
+    let mut count = 5;
+
+    // check the next arguments for flags
+    loop {
+        match args.peek().map(String::as_str) {
+            Some("-h") | Some("--help") => {
+                println!("Usage:
+    ping [-c count] host
+
+Examples:
+    ping -c 2 1.2.3.4
+        ping 1.2.3.4 two times");
+                return;
+            }
+            Some("-c") => {
+                args.next();
+                count = args.next().unwrap().parse().unwrap();
+            },
+            // now, we're finally past the options
+            Some(_) => break,
+            None => {
+                println!("Usage: ping [-c count] host");
+                return;
+            },
+        }
+    }
+
+    // the next argument should be the host
+    // TODO: also support host names
+    let ip: IpAddr = if let Some(host) = args.next() {
+        host.parse().expect("failed to parse IP address")
+    } else {
+        println!("Usage: ping [-c count] host");
+        return;
+    };
+
+    let ident = 0x1234;
+    let socket = IcmpSocket::bind(ident).expect("failed to open socket");
+    for seq_no in 0..count {
+        let send_time: [u8; 8] = time::date().timestamp_millis().to_ne_bytes();
+        // TODO: IPv6
+        let request = Icmpv4Repr::EchoRequest { ident, seq_no, data: &send_time };
+        let mut packet_buffer = vec![0u8; request.buffer_len()];
+        let mut packet = Icmpv4Packet::new_checked(&mut packet_buffer).unwrap();
+        request.emit(&mut packet, &ChecksumCapabilities::ignored());
+        socket.send_to(&packet_buffer, ip).expect("failed to send ping");
+
+        let mut recv_buffer = [0u8; 4096];
+        while socket.recv(&mut recv_buffer).expect("failed to receive ping reply") == 0 {
+            sleep(50);
+        }
+        let response_packet = Icmpv4Packet::new_checked(&recv_buffer).expect("received packet is invalid");
+        let response = Icmpv4Repr::parse(&response_packet, &ChecksumCapabilities::ignored()).expect("received packet is invalid");
+        if let Icmpv4Repr::EchoReply { seq_no, data, .. } = response {
+            let timestamp_ms = i64::from_ne_bytes(data[0..8].try_into().unwrap());
+            let timedelta = time::date().timestamp_millis() - timestamp_ms;
+            // TODO: ip address
+            println!("{} bytes: seq={}, time={}ms", data.len(), seq_no, timedelta);
+        } else {
+            println!("ignoring unexpected ICMP packet")
+        }
+    }
+}

--- a/os/application/ping/src/ping.rs
+++ b/os/application/ping/src/ping.rs
@@ -8,7 +8,7 @@ use core::net::IpAddr;
 
 use alloc::{string::String, vec};
 use concurrent::thread::sleep;
-use network::IcmpSocket;
+use network::{resolve_hostname, IcmpSocket};
 #[allow(unused_imports)]
 use runtime::*;
 use smoltcp::{phy::ChecksumCapabilities, wire::{Icmpv4Packet, Icmpv4Repr}};
@@ -48,13 +48,12 @@ Examples:
     }
 
     // the next argument should be the host
-    // TODO: also support host names
-    let ip: IpAddr = if let Some(host) = args.next() {
-        host.parse().expect("failed to parse IP address")
-    } else {
+    let Some(host) = args.next() else {
         println!("Usage: ping [-c count] host");
         return;
     };
+    // just take the first IP address
+    let ip = resolve_hostname(&host).into_iter().next().unwrap();
 
     let ident = 0x1234;
     let socket = IcmpSocket::bind(ident).expect("failed to open socket");

--- a/os/kernel/Cargo.toml
+++ b/os/kernel/Cargo.toml
@@ -37,7 +37,7 @@ goblin = { version = "0.9.3", default-features = false, features = ["elf32", "el
 tar-no-std = "0.3.3"
 pci_types = "0.10.0"
 bitflags = "2.9.0"
-smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp"] }
+smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp", "socket-icmp"] }
 mbrs = { version = "0.3.1", default-features = false, features = ["no-std"] }
 num_enum = { version = "0.7.3", default-features = false }
 

--- a/os/kernel/Cargo.toml
+++ b/os/kernel/Cargo.toml
@@ -37,7 +37,7 @@ goblin = { version = "0.9.3", default-features = false, features = ["elf32", "el
 tar-no-std = "0.3.3"
 pci_types = "0.10.0"
 bitflags = "2.9.0"
-smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "socket-dhcpv4", "socket-udp", "socket-tcp", "socket-icmp"] }
+smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "proto-ipv6", "socket-dhcpv4", "socket-udp", "socket-tcp", "socket-icmp"] }
 mbrs = { version = "0.3.1", default-features = false, features = ["no-std"] }
 num_enum = { version = "0.7.3", default-features = false }
 

--- a/os/kernel/Cargo.toml
+++ b/os/kernel/Cargo.toml
@@ -37,7 +37,7 @@ goblin = { version = "0.9.3", default-features = false, features = ["elf32", "el
 tar-no-std = "0.3.3"
 pci_types = "0.10.0"
 bitflags = "2.9.0"
-smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "proto-ipv6", "socket-dhcpv4", "socket-udp", "socket-tcp", "socket-icmp"] }
+smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "proto-ipv6", "socket-dhcpv4", "socket-udp", "socket-tcp", "socket-icmp", "socket-dns", "dns-max-result-count-4", "dns-max-server-count-4"] }
 mbrs = { version = "0.3.1", default-features = false, features = ["no-std"] }
 num_enum = { version = "0.7.3", default-features = false }
 

--- a/os/kernel/Cargo.toml
+++ b/os/kernel/Cargo.toml
@@ -37,7 +37,7 @@ goblin = { version = "0.9.3", default-features = false, features = ["elf32", "el
 tar-no-std = "0.3.3"
 pci_types = "0.10.0"
 bitflags = "2.9.0"
-smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "medium-ethernet", "proto-ipv4", "socket-udp"] }
+smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp"] }
 mbrs = { version = "0.3.1", default-features = false, features = ["no-std"] }
 num_enum = { version = "0.7.3", default-features = false }
 

--- a/os/kernel/Cargo.toml
+++ b/os/kernel/Cargo.toml
@@ -37,7 +37,7 @@ goblin = { version = "0.9.3", default-features = false, features = ["elf32", "el
 tar-no-std = "0.3.3"
 pci_types = "0.10.0"
 bitflags = "2.9.0"
-smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp", "socket-icmp"] }
+smoltcp = { version = "0.12.0", default-features = false, features = ["alloc", "log", "socket-dhcpv4", "socket-udp", "socket-tcp", "socket-icmp"] }
 mbrs = { version = "0.3.1", default-features = false, features = ["no-std"] }
 num_enum = { version = "0.7.3", default-features = false }
 

--- a/os/kernel/src/lib.rs
+++ b/os/kernel/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(abi_x86_interrupt)]
 #![feature(ptr_metadata)]
 #![feature(let_chains)]
+#![feature(map_try_insert)]
 #![allow(internal_features)]
 #![no_std]
 

--- a/os/kernel/src/network/mod.rs
+++ b/os/kernel/src/network/mod.rs
@@ -7,7 +7,7 @@ use log::info;
 use smoltcp::iface::{Interface, SocketHandle, SocketSet};
 use smoltcp::socket::{icmp, tcp, udp};
 use smoltcp::time::Instant;
-use smoltcp::wire::IpAddress;
+use smoltcp::wire::{IpAddress, IpCidr};
 use spin::{Once, RwLock};
 use crate::device::rtl8139::Rtl8139;
 use crate::{pci_bus, scheduler, timer};
@@ -57,6 +57,16 @@ pub fn rtl8139() -> Option<Arc<Rtl8139>> {
 
 pub fn add_interface(interface: Interface) {
     INTERFACES.write().push(interface);
+}
+
+pub fn get_ip_addresses() -> Vec<IpAddress> {
+    INTERFACES
+        .read()
+        .iter()
+        .map(Interface::ip_addrs)
+        .flatten()
+        .map(IpCidr::address)
+        .collect()
 }
 
 pub fn open_udp() -> SocketHandle {

--- a/os/kernel/src/network/mod.rs
+++ b/os/kernel/src/network/mod.rs
@@ -5,9 +5,9 @@ use core::ops::Deref;
 use core::ptr;
 use log::info;
 use smoltcp::iface::{Interface, SocketHandle, SocketSet};
-use smoltcp::socket::udp;
+use smoltcp::socket::udp::{self, UdpMetadata};
 use smoltcp::time::Instant;
-use smoltcp::wire::Ipv4Address;
+use smoltcp::wire::IpAddress;
 use spin::{Once, RwLock};
 use crate::device::rtl8139::Rtl8139;
 use crate::{pci_bus, scheduler, timer};
@@ -18,6 +18,9 @@ static RTL8139: Once<Arc<Rtl8139>> = Once::new();
 static INTERFACES: RwLock<Vec<Interface>> = RwLock::new(Vec::new());
 static SOCKETS: Once<RwLock<SocketSet>> = Once::new();
 
+#[derive(Debug)]
+#[repr(u8)]
+#[non_exhaustive]
 pub enum SocketType {
     Udp
 }
@@ -56,7 +59,7 @@ pub fn add_interface(interface: Interface) {
     INTERFACES.write().push(interface);
 }
 
-pub fn open_socket(protocol: SocketType) -> SocketHandle {
+pub fn open_socket(protocol: SocketType) -> Option<SocketHandle> {
     let sockets = SOCKETS.get().expect("Socket set not initialized!");
 
     let rx_buffer = udp::PacketBuffer::new(
@@ -70,9 +73,10 @@ pub fn open_socket(protocol: SocketType) -> SocketHandle {
 
     let socket = match protocol {
         SocketType::Udp => udp::Socket::new(rx_buffer, tx_buffer),
+        _ => return None,
     };
 
-    sockets.write().add(socket)
+    Some(sockets.write().add(socket))
 }
 
 pub fn close_socket(handle: SocketHandle) {
@@ -87,11 +91,18 @@ pub fn bind_udp(handle: SocketHandle, port: u16) -> Result<(), udp::BindError> {
     socket.bind(port)
 }
 
-pub fn send_datagram(handle: SocketHandle, destination: Ipv4Address, port: u16, data: &[u8]) -> Result<(), udp::SendError> {
+pub fn send_datagram(handle: SocketHandle, destination: IpAddress, port: u16, data: &[u8]) -> Result<(), udp::SendError> {
     let mut sockets = SOCKETS.get().expect("Socket set not initialized!").write();
     let socket = sockets.get_mut::<udp::Socket>(handle);
 
     socket.send_slice(data, (destination, port))
+}
+
+pub fn receive_datagram(handle: SocketHandle, data: &mut [u8]) -> Result<(usize, UdpMetadata), udp::RecvError> {
+    let mut sockets = SOCKETS.get().expect("Socket set not initialized!").write();
+    let socket = sockets.get_mut::<udp::Socket>(handle);
+
+    socket.recv_slice(data)
 }
 
 fn poll_sockets() {

--- a/os/kernel/src/network/mod.rs
+++ b/os/kernel/src/network/mod.rs
@@ -300,3 +300,18 @@ fn poll_sockets() {
         }
     }
 }
+
+pub(crate) fn close_sockets_for_process(process: &mut Process) {
+    let mut lock = SOCKET_PROCESS.write();
+    let mut sockets = SOCKETS.get().expect("Socket set not initialized!").write();
+    let handles: Vec<_> = lock
+        .iter()
+        .filter(|(_handle, proc)| ***proc == *process)
+        .map(|(handle, _proc)| handle)
+        .copied()
+        .collect();
+    for handle in handles {
+        lock.remove(&handle).unwrap();
+        sockets.remove(handle);
+    }
+}

--- a/os/kernel/src/network/mod.rs
+++ b/os/kernel/src/network/mod.rs
@@ -5,11 +5,10 @@ use core::ops::Deref;
 use core::ptr;
 use log::info;
 use smoltcp::iface::{self, Interface, SocketHandle, SocketSet};
-use smoltcp::socket::{icmp, tcp, udp};
+use smoltcp::socket::{dhcpv4, icmp, tcp, udp, Socket};
 use smoltcp::time::Instant;
-use smoltcp::wire::{HardwareAddress, IpAddress, Ipv4Address, IpCidr};
+use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr};
 use spin::{Once, RwLock};
-use crate::device::qemu_cfg;
 use crate::device::rtl8139::Rtl8139;
 use crate::{pci_bus, scheduler, timer};
 use crate::process::thread::Thread;
@@ -46,39 +45,28 @@ pub fn init() {
             loop { poll_sockets(); }
         }
         scheduler().ready(Thread::new_kernel_thread(poll, "RTL8139"));
+        
+        // Set up network interface
+        let time = timer().systime_ms();
+        let mut conf = iface::Config::new(HardwareAddress::from(rtl8139.read_mac_address()));
+        conf.random_seed = time as u64;
 
-        // Set up network interface for emulated QEMU network (IP: 10.0.2.15, Gateway: 10.0.2.2)
-        if qemu_cfg::is_available() {
-            let time = timer().systime_ms();
-            let mut conf = iface::Config::new(HardwareAddress::from(rtl8139.read_mac_address()));
-            conf.random_seed = time as u64;
+        // The Smoltcp interface struct wants a mutable reference to the device.
+        // However, the RTL8139 driver is designed to work with shared references.
+        // Since smoltcp does not actually store the mutable reference anywhere,
+        // we can safely cast the shared reference to a mutable one.
+        // (Actually, I am not sure why the smoltcp interface wants a mutable reference to the device,
+        // since it does not modify the device itself.)
+        let device = unsafe { ptr::from_ref(rtl8139.deref()).cast_mut().as_mut().unwrap() };
+        add_interface(Interface::new(conf, device, Instant::from_millis(time as i64)));
 
-            // The Smoltcp interface struct wants a mutable reference to the device.
-            // However, the RTL8139 driver is designed to work with shared references.
-            // Since smoltcp does not actually store the mutable reference anywhere,
-            // we can safely cast the shared reference to a mutable one.
-            // (Actually, I am not sure why the smoltcp interface wants a mutable reference to the device,
-            // since it does not modify the device itself.)
-            let device = unsafe { ptr::from_ref(rtl8139.deref()).cast_mut().as_mut().unwrap() };
-            let mut interface = Interface::new(conf, device, Instant::from_millis(time as i64));
-            interface.update_ip_addrs(|ips| {
-                ips.push(IpCidr::new(IpAddress::Ipv4(Ipv4Address::new(10, 0, 2, 15)), 24))
-                    .expect("Failed to add IP address");
-            });
-            interface
-                .routes_mut()
-                .add_default_ipv4_route(Ipv4Address::new(10, 0, 2, 2))
-                .expect("Failed to add default route");
-
-            add_interface(interface);
-        }
-    }
-}
-
-fn rtl8139() -> Option<Arc<Rtl8139>> {
-    match RTL8139.get() {
-        Some(rtl8139) => Some(Arc::clone(rtl8139)),
-        None => None
+        // request an IP address via DHCP
+        let dhcp_socket = dhcpv4::Socket::new();
+        SOCKETS
+            .get()
+            .expect("Socket set not initialized!")
+            .write()
+            .add(dhcp_socket);
     }
 }
 
@@ -248,7 +236,44 @@ fn poll_sockets() {
     // to work with a shared reference. We can safely cast the shared reference to a mutable.
     let device = unsafe { ptr::from_ref(rtl8139.deref()).cast_mut().as_mut().unwrap() };
 
+    // DHCP handling is based on https://github.com/smoltcp-rs/smoltcp/blob/main/examples/dhcp_client.rs
     for interface in interfaces.iter_mut() {
         interface.poll(time, device, &mut sockets);
+        for (_handle, socket) in sockets.iter_mut() {
+            if let Socket::Dhcpv4(dhcp) = socket {
+                if let Some(event) = dhcp.poll() {
+                    match event {
+                        dhcpv4::Event::Deconfigured => {
+                            info!("lost DHCP lease");
+                            interface.update_ip_addrs(|addrs| addrs.clear());
+                            interface.routes_mut().remove_default_ipv4_route();
+                        },
+                        dhcpv4::Event::Configured(config) => {
+                            info!("acquired DHCP lease:");
+                            info!("IP address: {}", config.address);
+                            interface.update_ip_addrs(|addrs| {
+                                addrs.clear();
+                                addrs.push(IpCidr::Ipv4(config.address)).unwrap();
+                            });
+
+                            if let Some(router) = config.router {
+                                info!("default gateway: {}", router);
+                                interface
+                                    .routes_mut()
+                                    .add_default_ipv4_route(router)
+                                    .unwrap();
+                            } else {
+                                info!("no default gateway");
+                                interface
+                                    .routes_mut()
+                                    .remove_default_ipv4_route();
+                            }
+                            // TODO: make use of this
+                            info!("DNS servers: {:?}", config.dns_servers);
+                        },
+                    }
+                }
+            }
+        }
     }
 }

--- a/os/kernel/src/process/process.rs
+++ b/os/kernel/src/process/process.rs
@@ -10,7 +10,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::Relaxed;
-use crate::{ process_manager, scheduler};
+use crate::{ network, process_manager, scheduler};
 use crate::memory::pages::Paging;
 use crate::memory::vmm::VirtualAddressSpace;
 
@@ -70,5 +70,11 @@ impl PartialEq for Process {
 impl core::fmt::Debug for Process {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Process").field("id", &self.id).finish()
+    }
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        network::close_sockets_for_process(self)
     }
 }

--- a/os/kernel/src/process/process.rs
+++ b/os/kernel/src/process/process.rs
@@ -60,3 +60,15 @@ impl Process {
     }
 
 }
+
+impl PartialEq for Process {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl core::fmt::Debug for Process {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Process").field("id", &self.id).finish()
+    }
+}

--- a/os/kernel/src/syscall/mod.rs
+++ b/os/kernel/src/syscall/mod.rs
@@ -10,6 +10,7 @@
 pub mod sys_naming;
 pub mod sys_terminal;
 pub mod sys_concurrent;
+pub mod sys_net;
 pub mod sys_time;
 pub mod sys_vmem;
 

--- a/os/kernel/src/syscall/sys_naming.rs
+++ b/os/kernel/src/syscall/sys_naming.rs
@@ -61,7 +61,7 @@ pub unsafe extern "sysv64" fn sys_touch(path: *const u8) -> isize {
 }
 
 /// Convert a raw pointer resulting from a CString to a UTF-8 String
-unsafe fn ptr_to_string(ptr: *const u8) -> Result<String, Errno> {
+pub(super) unsafe fn ptr_to_string(ptr: *const u8) -> Result<String, Errno> {
     if ptr.is_null() {
         return Err(Errno::EBADSTR);
     }

--- a/os/kernel/src/syscall/sys_net.rs
+++ b/os/kernel/src/syscall/sys_net.rs
@@ -1,0 +1,93 @@
+use core::str::FromStr;
+
+use log::{info, warn};
+use smoltcp::{iface::SocketHandle, socket::udp::{self, BindError}, wire::IpAddress};
+use syscall::return_vals::Errno;
+
+use crate::{network::{bind_udp, close_socket, open_socket, receive_datagram, send_datagram, SocketType}, syscall::sys_naming::ptr_to_string};
+
+/// This module contains all network-related system calls.
+
+pub fn sys_sock_open(protocol: SocketType) -> isize {
+    info!("opening a {protocol:?} socket");
+    // TODO: what happens when we get a type thats not in the enum?
+    // TODO: can we somehow bind this socket to the process,
+    // so that we know which process has opened this socket
+    // and are able to close it on process exit
+    if let Some(handle) = open_socket(protocol) {
+        // handle.0 is private, sadly, so just hope this works
+        unsafe { core::mem::transmute::<SocketHandle, usize>(handle) }.try_into().unwrap()
+    } else {
+        // unknown protocol
+        Errno::ENOTSUP.into()
+    }
+}
+
+pub fn sys_sock_bind(handle: SocketHandle, protocol: SocketType, port: u16) -> isize  {
+    // TODO: somehow check that the protocol is correct for handle?
+    // TODO: allow binding to anything other than ::
+    info!("binding {handle:?} to {port}");
+    match match protocol {
+        SocketType::Udp => bind_udp(handle, port),
+    } {
+        Ok(()) => 0,
+        // socket has already been opened
+        Err(BindError::InvalidState) => Errno::EEXIST.into(),
+        // port is zero
+        Err(BindError::Unaddressable) => Errno::EINVAL.into(),
+    }
+}
+
+pub unsafe fn sys_sock_send(
+    handle: SocketHandle,
+    protocol: SocketType,
+    addr_ptr: *const u8,
+    port: u16,
+    data: *const u8,
+    len: usize,
+) -> isize {
+    if let Ok(addr_str) = unsafe { ptr_to_string(addr_ptr) } && let Ok(addr) = IpAddress::from_str(&addr_str) {
+        let data = unsafe { core::slice::from_raw_parts(data, len) };
+        match match protocol {
+            SocketType::Udp => send_datagram(handle, addr, port, data),
+            _ => return Errno::ENOTSUP.into(),
+        } {
+            Ok(()) => data.len().try_into().unwrap(),
+            // host or port are missing or zero
+            Err(udp::SendError::Unaddressable) => Errno::EINVAL.into(),
+            // TODO: drop? return 0?
+            Err(udp::SendError::BufferFull) => Errno::EBUSY.into(),
+        }
+    } else {
+        Errno::EINVAL.into()
+    }
+}
+
+pub unsafe fn sys_sock_receive(
+    handle: SocketHandle,
+    protocol: SocketType,
+    data_ptr: *mut u8,
+    data_len: usize,
+) -> isize {
+    let data = unsafe { core::slice::from_raw_parts_mut(data_ptr, data_len) };
+    match match protocol {
+        SocketType::Udp => receive_datagram(handle, data),
+        _ => return Errno::ENOTSUP.into(),
+    } {
+        // TODO: also pass the metadata
+        Ok((len, metadata)) => len.try_into().unwrap(),
+        // discard truncated packet
+        Err(udp::RecvError::Truncated) => {
+            warn!("discarding truncated incoming packet");
+            0
+        },
+        // if we got no data, that is okay
+        Err(udp::RecvError::Exhausted) => 0,
+    }
+}
+
+pub fn sys_sock_close(handle: SocketHandle) -> isize {
+    info!("closing {handle} socket");
+    close_socket(handle);
+    0
+}

--- a/os/kernel/src/syscall/sys_net.rs
+++ b/os/kernel/src/syscall/sys_net.rs
@@ -1,10 +1,10 @@
 use core::str::FromStr;
 
 use log::{info, warn};
-use smoltcp::{iface::SocketHandle, socket::udp::{self, BindError}, wire::IpAddress};
+use smoltcp::{iface::SocketHandle, socket::{udp, tcp}, wire::IpAddress};
 use syscall::return_vals::Errno;
 
-use crate::{network::{bind_udp, close_socket, open_socket, receive_datagram, send_datagram, SocketType}, syscall::sys_naming::ptr_to_string};
+use crate::{network::{accept_tcp, bind_tcp, bind_udp, close_socket, connect_tcp, open_tcp, open_udp, receive_datagram, receive_tcp, send_datagram, send_tcp, SocketType}, syscall::sys_naming::ptr_to_string};
 
 /// This module contains all network-related system calls.
 
@@ -14,52 +14,104 @@ pub fn sys_sock_open(protocol: SocketType) -> isize {
     // TODO: can we somehow bind this socket to the process,
     // so that we know which process has opened this socket
     // and are able to close it on process exit
-    if let Some(handle) = open_socket(protocol) {
-        // handle.0 is private, sadly, so just hope this works
-        unsafe { core::mem::transmute::<SocketHandle, usize>(handle) }.try_into().unwrap()
-    } else {
-        // unknown protocol
-        Errno::ENOTSUP.into()
-    }
+    #[allow(unreachable_patterns)]
+    let handle = match protocol {
+        SocketType::Udp => open_udp(),
+        SocketType::Tcp => open_tcp(),
+        _ => return Errno::ENOTSUP.into(),
+    };
+    // handle.0 is private, sadly, so just hope this works
+    unsafe { core::mem::transmute::<SocketHandle, usize>(handle) }.try_into().unwrap()
 }
 
 pub fn sys_sock_bind(handle: SocketHandle, protocol: SocketType, port: u16) -> isize  {
     // TODO: somehow check that the protocol is correct for handle?
     // TODO: allow binding to anything other than ::
     info!("binding {handle:?} to {port}");
-    match match protocol {
-        SocketType::Udp => bind_udp(handle, port),
-    } {
-        Ok(()) => 0,
-        // socket has already been opened
-        Err(BindError::InvalidState) => Errno::EEXIST.into(),
-        // port is zero
-        Err(BindError::Unaddressable) => Errno::EINVAL.into(),
+    #[allow(unreachable_patterns)]
+    match protocol {
+        SocketType::Udp => match bind_udp(handle, port) {
+            Ok(()) => 0,
+            // socket has already been opened
+            Err(udp::BindError::InvalidState) => Errno::EEXIST.into(),
+            // port is zero
+            Err(udp::BindError::Unaddressable) => Errno::EINVAL.into(),
+        },
+        SocketType::Tcp => match bind_tcp(handle, port) {
+            Ok(()) => 0,
+            // socket has already been opened
+            Err(tcp::ListenError::InvalidState) => Errno::EEXIST.into(),
+            // port is zero
+            Err(tcp::ListenError::Unaddressable) => Errno::EINVAL.into(),
+        },
+        _ => Errno::ENOTSUP.into(),
+    }
+}
+
+pub unsafe fn sys_sock_accept(
+    handle: SocketHandle,
+    protocol: SocketType,
+) -> isize {
+    if matches!(protocol, SocketType::Tcp) {
+        match accept_tcp(handle) {
+            Ok(port) => port.try_into().unwrap(),
+            Err(e) => panic!("failed to accept: {e:?}"),
+        }
+    } else {
+        Errno::ENOTSUP.into()
+    }
+}
+
+pub unsafe fn sys_sock_connect(
+    handle: SocketHandle,
+    protocol: SocketType,
+    addr_ptr: *const u8,
+    port: u16,
+) -> isize {
+    if matches!(protocol, SocketType::Tcp) {
+        if let Ok(addr_str) = unsafe { ptr_to_string(addr_ptr) } && let Ok(addr) = IpAddress::from_str(&addr_str) {
+            match connect_tcp(handle, addr, port) {
+                Ok(port) => port.try_into().unwrap(),
+                Err(e) => panic!("failed to accept: {e:?}"),
+            }
+        } else {
+            Errno::EINVAL.into()
+        }
+    } else {
+        Errno::ENOTSUP.into()
     }
 }
 
 pub unsafe fn sys_sock_send(
     handle: SocketHandle,
     protocol: SocketType,
-    addr_ptr: *const u8,
-    port: u16,
     data: *const u8,
     len: usize,
+    addr_ptr: *const u8,
+    port: u16,
 ) -> isize {
-    if let Ok(addr_str) = unsafe { ptr_to_string(addr_ptr) } && let Ok(addr) = IpAddress::from_str(&addr_str) {
-        let data = unsafe { core::slice::from_raw_parts(data, len) };
-        match match protocol {
-            SocketType::Udp => send_datagram(handle, addr, port, data),
-            _ => return Errno::ENOTSUP.into(),
-        } {
-            Ok(()) => data.len().try_into().unwrap(),
-            // host or port are missing or zero
-            Err(udp::SendError::Unaddressable) => Errno::EINVAL.into(),
-            // TODO: drop? return 0?
-            Err(udp::SendError::BufferFull) => Errno::EBUSY.into(),
-        }
-    } else {
-        Errno::EINVAL.into()
+    let data = unsafe { core::slice::from_raw_parts(data, len) };
+    #[allow(unreachable_patterns)]
+    match protocol {
+        SocketType::Udp => {
+            if let Ok(addr_str) = unsafe { ptr_to_string(addr_ptr) } && let Ok(addr) = IpAddress::from_str(&addr_str) {
+                match send_datagram(handle, addr, port, data) {
+                    Ok(()) => data.len().try_into().unwrap(),
+                    // host or port are missing or zero
+                    Err(udp::SendError::Unaddressable) => Errno::EINVAL.into(),
+                    // TODO: drop? return 0?
+                    Err(udp::SendError::BufferFull) => Errno::EBUSY.into(),
+                }
+            } else {
+                Errno::EINVAL.into()
+            }
+        },
+        SocketType::Tcp => match send_tcp(handle, data) {
+            Ok(len) => len.try_into().unwrap(),
+            // socket can't send (yet)
+            Err(tcp::SendError::InvalidState) => Errno::EINVAL.into(),
+        },
+        _ => Errno::ENOTSUP.into(),
     }
 }
 
@@ -70,19 +122,29 @@ pub unsafe fn sys_sock_receive(
     data_len: usize,
 ) -> isize {
     let data = unsafe { core::slice::from_raw_parts_mut(data_ptr, data_len) };
-    match match protocol {
-        SocketType::Udp => receive_datagram(handle, data),
-        _ => return Errno::ENOTSUP.into(),
-    } {
-        // TODO: also pass the metadata
-        Ok((len, metadata)) => len.try_into().unwrap(),
-        // discard truncated packet
-        Err(udp::RecvError::Truncated) => {
-            warn!("discarding truncated incoming packet");
-            0
+    #[allow(unreachable_patterns)]
+    match protocol {
+        SocketType::Udp => match receive_datagram(handle, data) {
+            // TODO: also pass the metadata
+            Ok((len, metadata)) => len.try_into().unwrap(),
+            // discard truncated packet
+            Err(udp::RecvError::Truncated) => {
+                warn!("discarding truncated incoming packet");
+                0
+            },
+            // if we got no data, that is okay
+            Err(udp::RecvError::Exhausted) => 0,
         },
-        // if we got no data, that is okay
-        Err(udp::RecvError::Exhausted) => 0,
+        SocketType::Tcp => match receive_tcp(handle, data) {
+            Ok(len) => len.try_into().unwrap(),
+            Err(tcp::RecvError::InvalidState) => {
+                warn!("TCP socket is in an invalid state");
+                Errno::EINVALH.into()
+            },
+            // the remote host closed the connection
+            Err(tcp::RecvError::Finished) => Errno::ECONNRESET.into(),
+        }
+        _ => Errno::ENOTSUP.into(),
     }
 }
 

--- a/os/kernel/src/syscall/sys_net.rs
+++ b/os/kernel/src/syscall/sys_net.rs
@@ -12,9 +12,6 @@ use crate::{network::{accept_tcp, bind_icmp, bind_tcp, bind_udp, close_socket, c
 pub fn sys_sock_open(protocol: SocketType) -> isize {
     info!("opening a {protocol:?} socket");
     // TODO: what happens when we get a type thats not in the enum?
-    // TODO: can we somehow bind this socket to the process,
-    // so that we know which process has opened this socket
-    // and are able to close it on process exit
     #[allow(unreachable_patterns)]
     let handle = match protocol {
         SocketType::Udp => open_udp(),

--- a/os/kernel/src/syscall/syscall_dispatcher.rs
+++ b/os/kernel/src/syscall/syscall_dispatcher.rs
@@ -15,6 +15,7 @@ use x86_64::registers::control::{Efer, EferFlags};
 use x86_64::registers::model_specific::{KernelGsBase, LStar, Star};
 use x86_64::structures::gdt::SegmentSelector;
 use x86_64::{PrivilegeLevel, VirtAddr};
+use crate::syscall::sys_net::{sys_sock_bind, sys_sock_close, sys_sock_open, sys_sock_receive, sys_sock_send};
 use crate::syscall::sys_vmem::sys_map_memory;
 use crate::syscall::sys_time::{sys_get_date, sys_get_system_time, sys_set_date, };
 use crate::syscall::sys_concurrent::{sys_process_execute_binary, sys_process_exit, sys_process_id, sys_thread_create, sys_thread_exit,
@@ -111,7 +112,12 @@ impl SyscallTable {
                 sys_touch as *const _,
                 sys_readdir as *const _,
                 sys_cwd as *const _,
-                sys_cd as *const _,                
+                sys_cd as *const _,
+                sys_sock_open as *const _,
+                sys_sock_bind as *const _,
+                sys_sock_send as *const _,
+                sys_sock_receive as *const _,
+                sys_sock_close as *const _,
             ],
         }
     }

--- a/os/kernel/src/syscall/syscall_dispatcher.rs
+++ b/os/kernel/src/syscall/syscall_dispatcher.rs
@@ -15,7 +15,7 @@ use x86_64::registers::control::{Efer, EferFlags};
 use x86_64::registers::model_specific::{KernelGsBase, LStar, Star};
 use x86_64::structures::gdt::SegmentSelector;
 use x86_64::{PrivilegeLevel, VirtAddr};
-use crate::syscall::sys_net::{sys_sock_accept, sys_sock_bind, sys_sock_close, sys_sock_connect, sys_sock_open, sys_sock_receive, sys_sock_send};
+use crate::syscall::sys_net::{sys_get_ip_adresses, sys_sock_accept, sys_sock_bind, sys_sock_close, sys_sock_connect, sys_sock_open, sys_sock_receive, sys_sock_send};
 use crate::syscall::sys_vmem::sys_map_memory;
 use crate::syscall::sys_time::{sys_get_date, sys_get_system_time, sys_set_date, };
 use crate::syscall::sys_concurrent::{sys_process_execute_binary, sys_process_exit, sys_process_id, sys_thread_create, sys_thread_exit,
@@ -120,6 +120,7 @@ impl SyscallTable {
                 sys_sock_send as *const _,
                 sys_sock_receive as *const _,
                 sys_sock_close as *const _,
+                sys_get_ip_adresses as *const _,
             ],
         }
     }

--- a/os/kernel/src/syscall/syscall_dispatcher.rs
+++ b/os/kernel/src/syscall/syscall_dispatcher.rs
@@ -15,7 +15,7 @@ use x86_64::registers::control::{Efer, EferFlags};
 use x86_64::registers::model_specific::{KernelGsBase, LStar, Star};
 use x86_64::structures::gdt::SegmentSelector;
 use x86_64::{PrivilegeLevel, VirtAddr};
-use crate::syscall::sys_net::{sys_sock_bind, sys_sock_close, sys_sock_open, sys_sock_receive, sys_sock_send};
+use crate::syscall::sys_net::{sys_sock_accept, sys_sock_bind, sys_sock_close, sys_sock_connect, sys_sock_open, sys_sock_receive, sys_sock_send};
 use crate::syscall::sys_vmem::sys_map_memory;
 use crate::syscall::sys_time::{sys_get_date, sys_get_system_time, sys_set_date, };
 use crate::syscall::sys_concurrent::{sys_process_execute_binary, sys_process_exit, sys_process_id, sys_thread_create, sys_thread_exit,
@@ -115,6 +115,8 @@ impl SyscallTable {
                 sys_cd as *const _,
                 sys_sock_open as *const _,
                 sys_sock_bind as *const _,
+                sys_sock_accept as *const _,
+                sys_sock_connect as *const _,
                 sys_sock_send as *const _,
                 sys_sock_receive as *const _,
                 sys_sock_close as *const _,

--- a/os/library/network/Cargo.toml
+++ b/os/library/network/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+edition = "2024"
+name = "network"
+version = "0.1.0"
+authors = ["Niklas Sombert <niklas.sombert@uni-duesseldorf.de"]
+
+[dependencies]
+syscall = { path = "../syscall" }

--- a/os/library/network/src/lib.rs
+++ b/os/library/network/src/lib.rs
@@ -39,10 +39,10 @@ impl UdpSocket {
         syscall(SystemCall::SockSend, &[
             self.handle,
             protocol,
-            addr.as_bytes_with_nul().as_ptr() as usize,
-            address.port().into(),
             buf.as_ptr() as usize,
             buf.len(),
+            addr.as_bytes_with_nul().as_ptr() as usize,
+            address.port().into(),
         ])
             .map_err(|errno| match errno {
                 Errno::EINVAL => NetworkError::InvalidAddress,
@@ -74,6 +74,128 @@ impl UdpSocket {
 impl Drop for UdpSocket {
     fn drop(&mut self) {
         let protocol = 0;
+        syscall(SystemCall::SockClose, &[self.handle, protocol])
+            .expect("failed to close socket");
+    }
+}
+
+pub struct TcpListener {
+    handle: usize,
+    /// the (local) address this socket is bound to
+    address: SocketAddr
+}
+
+impl TcpListener {
+    pub fn bind(address: SocketAddr) -> Result<Self, NetworkError> {
+        let protocol = 1;
+        let handle = syscall(SystemCall::SockOpen, &[protocol])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+        // TODO: also pass the address
+        syscall(SystemCall::SockBind, &[handle, protocol, address.port().into()])
+            .map_err(|errno| match errno {
+                Errno::EEXIST => panic!("socket as already been opened"),
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                errno => NetworkError::Unknown(errno),
+            })?;
+        Ok(Self { handle, address })
+    }
+
+    pub fn accept(&self) -> Result<TcpStream, NetworkError> {
+        let protocol = 1;
+        let peer_port: u16 = syscall(SystemCall::SockAccept, &[self.handle, protocol])
+            .map_err(|errno| match errno {
+                Errno::EEXIST => panic!("socket as already been opened"),
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                errno => NetworkError::Unknown(errno),
+            })?
+            .try_into().unwrap();
+        // TODO: also pass the remote SocketAddr
+        let peer_address = SocketAddr::V4(
+            SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), peer_port)
+        );
+        Ok(TcpStream { handle: self.handle, local_address: self.address, peer_address })
+    }
+}
+
+impl Drop for TcpListener {
+    fn drop(&mut self) {
+        // TODO: just drop this when all connections are gone
+    }
+}
+
+
+pub struct TcpStream {
+    handle: usize,
+    local_address: SocketAddr,
+    peer_address: SocketAddr,
+}
+
+impl TcpStream {
+    pub fn connect(address: SocketAddr) -> Result<Self, NetworkError> {
+        let protocol = 1;
+        // valid addresses do not contain 0 bytes
+        let addr = CString::new(address.ip().to_string()).unwrap();
+        let handle = syscall(SystemCall::SockOpen, &[protocol])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+        let local_port: u16 = syscall(SystemCall::SockConnect, &[
+            handle,
+            protocol,
+            addr.as_bytes_with_nul().as_ptr() as usize,
+            address.port().into(),
+        ])
+            .map_err(|errno| match errno {
+                Errno::EEXIST => panic!("socket as already been opened"),
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                errno => NetworkError::Unknown(errno),
+            })?
+            .try_into().unwrap();
+        let local_address = SocketAddr::V4(
+            SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), local_port)
+        );
+        Ok(Self { handle, local_address, peer_address: address })
+    }
+
+    pub fn write(&self, buf: &[u8]) -> Result<usize, NetworkError> {
+        let protocol = 1;
+        syscall(SystemCall::SockSend, &[
+            self.handle,
+            protocol,
+            buf.as_ptr() as usize,
+            buf.len(),
+        ])
+            .map_err(|errno| match errno {
+                Errno::EINVAL => panic!("socket can't send"),
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize, NetworkError> {
+        let protocol = 1;
+        let num_bytes = syscall(SystemCall::SockReceive, &[
+            self.handle,
+            protocol,
+            buf.as_ptr() as usize,
+            buf.len(),
+        ])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+
+        Ok(num_bytes)
+    }
+}
+
+impl Drop for TcpStream {
+    fn drop(&mut self) {
+        let protocol = 1;
         syscall(SystemCall::SockClose, &[self.handle, protocol])
             .expect("failed to close socket");
     }

--- a/os/library/network/src/lib.rs
+++ b/os/library/network/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 extern crate alloc;
 
-use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use core::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use alloc::{ffi::CString, string::ToString};
 use syscall::{return_vals::Errno, syscall, SystemCall};
@@ -200,6 +200,73 @@ impl Drop for TcpStream {
             .expect("failed to close socket");
     }
 }
+
+pub struct IcmpSocket {
+    handle: usize,
+    ident: u16,
+}
+
+impl IcmpSocket {
+    pub fn bind(ident: u16) -> Result<Self, NetworkError> {
+        let protocol = 2;
+        let handle = syscall(SystemCall::SockOpen, &[protocol])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+        syscall(SystemCall::SockBind, &[handle, protocol, ident.into()])
+            .map_err(|errno| match errno {
+                Errno::EEXIST => panic!("socket has already been openend"),
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                errno => NetworkError::Unknown(errno)
+            })?;
+        Ok(Self { handle, ident })
+    }
+
+    pub fn send_to(&self, buf: &[u8], address: IpAddr) -> Result<usize, NetworkError> {
+        let protocol = 2;
+        // valid addresses do not contain 0 bytes
+        let addr = CString::new(address.to_string()).unwrap();
+        syscall(SystemCall::SockSend, &[
+            self.handle,
+            protocol,
+            buf.as_ptr() as usize,
+            buf.len(),
+            addr.as_bytes_with_nul().as_ptr() as usize,
+        ])
+            .map_err(|errno| match errno {
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                Errno::EBUSY => NetworkError::DeviceBusy,
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })
+    }
+
+     pub fn recv(&self, buf: &mut [u8]) -> Result<usize, NetworkError> {
+        let protocol = 2;
+        let num_bytes = syscall(SystemCall::SockReceive, &[
+            self.handle,
+            protocol,
+            buf.as_ptr() as usize,
+            buf.len(),
+        ])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+
+        Ok(num_bytes)
+    }
+}
+
+impl Drop for IcmpSocket {
+    fn drop(&mut self) {
+        let protocol = 2;
+        syscall(SystemCall::SockClose, &[self.handle, protocol])
+            .expect("failed to close socket");
+    }
+}
+
 
 #[derive(Debug)]
 pub enum NetworkError {

--- a/os/library/network/src/lib.rs
+++ b/os/library/network/src/lib.rs
@@ -1,0 +1,87 @@
+//! This library provides access to the internet -- or other networks.
+
+#![no_std]
+extern crate alloc;
+
+use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use alloc::{ffi::CString, string::ToString};
+use syscall::{return_vals::Errno, syscall, SystemCall};
+
+pub struct UdpSocket {
+    handle: usize,
+    /// the (local) address this socket is bound to
+    address: SocketAddr,
+}
+
+impl UdpSocket {
+    pub fn bind(address: SocketAddr) -> Result<Self, NetworkError> {
+        let protocol = 0;
+        let handle = syscall(SystemCall::SockOpen, &[protocol])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+        // TODO: also pass the address
+        syscall(SystemCall::SockBind, &[handle, protocol, address.port().into()])
+            .map_err(|errno| match errno {
+                Errno::EEXIST => panic!("socket has already been openend"),
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                errno => NetworkError::Unknown(errno)
+            })?;
+        Ok(Self { handle, address })
+    }
+
+    pub fn send_to(&self, buf: &[u8], address: SocketAddr) -> Result<usize, NetworkError> {
+        let protocol = 0;
+        // valid addresses do not contain 0 bytes
+        let addr = CString::new(address.ip().to_string()).unwrap();
+        syscall(SystemCall::SockSend, &[
+            self.handle,
+            protocol,
+            addr.as_bytes_with_nul().as_ptr() as usize,
+            address.port().into(),
+            buf.as_ptr() as usize,
+            buf.len(),
+        ])
+            .map_err(|errno| match errno {
+                Errno::EINVAL => NetworkError::InvalidAddress,
+                Errno::EBUSY => NetworkError::DeviceBusy,
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })
+    }
+    
+    pub fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr), NetworkError> {
+        let protocol = 0;
+        let num_bytes = syscall(SystemCall::SockReceive, &[
+            self.handle,
+            protocol,
+            buf.as_ptr() as usize,
+            buf.len(),
+            // TODO: also get IP addr and port
+        ])
+            .map_err(|errno| match errno {
+                Errno::ENOTSUP => panic!("invalid protocol"),
+                errno => NetworkError::Unknown(errno),
+            })?;
+        let remote_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0));
+
+        Ok((num_bytes, remote_addr))
+    }
+}
+
+impl Drop for UdpSocket {
+    fn drop(&mut self) {
+        let protocol = 0;
+        syscall(SystemCall::SockClose, &[self.handle, protocol])
+            .expect("failed to close socket");
+    }
+}
+
+#[derive(Debug)]
+pub enum NetworkError {
+    DeviceBusy,
+    InvalidAddress,
+    Unknown(Errno),
+}

--- a/os/library/syscall/src/lib.rs
+++ b/os/library/syscall/src/lib.rs
@@ -49,6 +49,7 @@ pub enum SystemCall {
     SockSend,
     SockReceive,
     SockClose,
+    GetIpAddresses,
     // no syscall, just marking last number, see NUM_SYSCALLS
     // insert any new system calls before this marker
     LastEntryMarker,

--- a/os/library/syscall/src/lib.rs
+++ b/os/library/syscall/src/lib.rs
@@ -44,6 +44,8 @@ pub enum SystemCall {
     Cd,
     SockOpen,
     SockBind,
+    SockAccept,
+    SockConnect,
     SockSend,
     SockReceive,
     SockClose,

--- a/os/library/syscall/src/lib.rs
+++ b/os/library/syscall/src/lib.rs
@@ -42,6 +42,11 @@ pub enum SystemCall {
     Readdir,
     Cwd,
     Cd,
+    SockOpen,
+    SockBind,
+    SockSend,
+    SockReceive,
+    SockClose,
     // no syscall, just marking last number, see NUM_SYSCALLS
     // insert any new system calls before this marker
     LastEntryMarker,

--- a/os/library/syscall/src/return_vals.rs
+++ b/os/library/syscall/src/return_vals.rs
@@ -27,6 +27,7 @@ pub enum Errno {
     EBADSTR    = -11, // Bad string
     EBUSY      = -12, // Device busy
     ENOTSUP    = -13, // Operation not supported
+    ECONNRESET = -14, // Connection reset by peer
 }
 
 

--- a/os/library/syscall/src/return_vals.rs
+++ b/os/library/syscall/src/return_vals.rs
@@ -25,6 +25,8 @@ pub enum Errno {
     EINVALH    = -9,  // Invalid handle
     ENOTEMPTY  = -10, // Directory not empty
     EBADSTR    = -11, // Bad string
+    EBUSY      = -12, // Device busy
+    ENOTSUP    = -13, // Operation not supported
 }
 
 


### PR DESCRIPTION
This PR adds the `network` crate that allows applications to query for IP addresses and to create TCP, UDP and ICMP sockets. The socket API is modeled after the one found in the Rust standard library.

It also adds the `sys_sock_open`, `sys_sock_bind`, `sys_sock_accept`, `sys_sock_connect`, `sys_sock_send`, `sys_sock_receive`, `sys_sock_close` and `sys_get_ip_adresses` syscalls to make this work.
There's a global `SocketSet` and `SocketHandles` are global (since smoltcp seems to need this), but sockets are attached to a process and closed when it exits. Access to those sockets is checked.

IP addresses are passed as zero-terminated strings and can be both IPv4 and IPv6.

DHCPv4 and DNS also do work.

The following things are missing, but I think that can be added / changed later:
 * multiple interfaces (including loopback)
 * accepting multiple connections on a single listening TCP socket
 * DHCPv6 / SLAAC (smoltcp currently doesn't support this)

Also, IP addresses probably should not be strings. By using IPv4-mapped IPv6 addresses, every address could be a `u128` -- or two registers. This would be faster, but more code.

