### PR TITLE
refactor: use variant_count() instead of LastEntryMarker

### DIFF
--- a/docs/new-syscall.howto.md
+++ b/docs/new-syscall.howto.md
@@ -3,7 +3,7 @@
 ### Work to be done in User Mode
 
 1. You need to add an entry for your new system call in: `os/library/syscall`
-In `enum SysCall`. Insert your new system call name before `LastEntryMarker`.
+In `enum SysCall`.
 
 2. For using your new system call, see examples in `os/library`. A system call is typically used within a runtime library function, not directly within an application. *Important: Check params before firing a system call and abort if they are not valid.*
 

--- a/os/library/syscall/src/lib.rs
+++ b/os/library/syscall/src/lib.rs
@@ -7,7 +7,9 @@
    ╚═════════════════════════════════════════════════════════════════════════╝
 */
 #![no_std]
+#![feature(variant_count)]
 
+use core::mem;
 use crate::return_vals::SyscallResult;
 
 pub mod return_vals;
@@ -63,12 +65,9 @@ pub enum SystemCall {
     KeyboardRead,
     MapSystemInfo,
     Log,
-    // no syscall, just marking last number, see NUM_SYSCALLS
-    // insert any new system calls before this marker
-    LastEntryMarker,
 }
 
-pub const NUM_SYSCALLS: usize = SystemCall::LastEntryMarker as usize;
+pub const NUM_SYSCALLS: usize = mem::variant_count::<SystemCall>() as usize;
 
 ///
 /// Description:


### PR DESCRIPTION
Because D3OS already uses nightly, why not use the dedicated const function to get the number of enum variants?

See https://doc.rust-lang.org/std/mem/fn.variant_count.html