### PR TITLE
Fix wait-queue blocking and cross-core wakeups

### DIFF
--- a/os/kernel/src/process/scheduler.rs
+++ b/os/kernel/src/process/scheduler.rs
@@ -633,13 +633,23 @@ impl Scheduler {
             }
 
         // 2b) Check if the thread to be woken up is in the ready queue
-        if let Some(thread) = state.ready_queue.iter().find(|t| t.id() == tid && t.process().id() == pid) {
-                curr_thread.set_state(ThreadState::Ready);
+            if state.ready_queue.iter().any(|t| t.id() == tid && t.process().id() == pid) {
+                // Already runnable (e.g. a previous wakeup raced in); nothing to do
                 return true;
             }
         }
 
-        // 3) Thread not found in any known list.
+        // 3) Not found on this core. The thread may be blocked on the
+        // `blocked_list` of another core (the scheduler is core-local), so ask
+        // every other core to deblock it. The owning core's `Deblock` handler
+        // does the matching `inc_rq_len()`. Only broadcast for live threads to
+        // avoid waking stale (exited) waiters.
+        if is_thread_alive(tid) {
+            drop(state); // release ready_state before cross-core scheduling
+            schedule_on_all_others(MessageItem::Cmd(MessageCmd::Deblock { pid, tid }));
+            return true;
+        }
+
         false
     }
 

--- a/os/kernel/src/process/scheduler.rs
+++ b/os/kernel/src/process/scheduler.rs
@@ -566,6 +566,38 @@ impl Scheduler {
         (thread.process().id(), thread.id())
     }
 
+    /// Block the calling thread, but only if it should still wait.
+    pub fn block_if_parking<F>(&self, mut should_wait: F)
+    where
+        F: FnMut() -> bool,
+    {
+        let state = self.get_ready_state();
+
+        if !state.initialized {
+            return;
+        }
+
+        let thread = Scheduler::current(&state);
+        if thread.state() != ThreadState::Parking {
+            // A wakeup raced in between registering and blocking; do not block.
+            return;
+        }
+
+        if !should_wait() {
+            // The condition was satisfied while we were registering; a racing
+            // `unblock` may not have found us, so cancel the block ourselves.
+            thread.set_state(ThreadState::Running);
+            return;
+        }
+
+        {
+            let mut block_list = self.blocked_list.lock();
+            block_list.push(Arc::clone(&thread));
+        }
+        dec_rq_len();
+        self.block_and_switch(state);
+    }
+
     /// Unblock thread with given (pid, tid). \
     /// Returns true if thread was found and unblocked, false otherwise.
     pub fn unblock(&self, pid: Uuid, tid: usize) -> bool {

--- a/os/kernel/src/process/scheduler.rs
+++ b/os/kernel/src/process/scheduler.rs
@@ -621,6 +621,7 @@ impl Scheduler {
             // let mut state = self.get_ready_state();
             thread.set_state(ThreadState::Ready);
             state.ready_queue.push_front(Arc::clone(&thread));
+            inc_rq_len();
             return true;
         }
 

--- a/os/kernel/src/sync/wait_queue.rs
+++ b/os/kernel/src/sync/wait_queue.rs
@@ -13,7 +13,6 @@
 */
 
 use alloc::collections::VecDeque;
-use log::info;
 use uuid::Uuid;
 
 use crate::{process::core_local_storage::scheduler, sync::irqsave_spinlock::IrqSaveSpinlock};
@@ -30,13 +29,10 @@ impl WaitQueue {
     }
 
     /// Block until `pred()` becomes true.
-    pub fn wait<F>(&self, mut pred: F, message: &str)
+    pub fn wait<F>(&self, mut pred: F, _message: &str)
     where
         F: FnMut() -> bool,
     {
-        //        info!("WaitQueue::wait");
-        let (pid, tid) = scheduler().current_ids();
-
         loop {
             if pred() {
                 return;
@@ -50,25 +46,12 @@ impl WaitQueue {
                     return;
                 }
 
-                guard.push_back((pid, tid));
-
                 // park after we are visible to notifiers
-                scheduler().park_current();
+                let ids = scheduler().park_current();
+                guard.push_back(ids);
             }
 
-            scheduler().yield_now(); 
-        }
-
-        info!("WaitQueue::wait: Thread with PID={}, TID={} is now waiting, message = {}", pid, tid, message);
-
-        // Check predicate without acquiring the queue lock.
-        // The scheduler will block us, as long as no `notify_one` and `notify_all` have arrived
-        // But even after waking up we need to check for spurious wakeups, so we loop here.
-        loop {
-            if pred() {
-                return;
-            }
-            core::hint::spin_loop();
+            scheduler().block_if_parking(|| !pred());
         }
     }
 


### PR DESCRIPTION
Wait queue kept overflowing and burning CPU due to busy-spin. The scheduler forgot to increase run queue length, and to search in other cores than the one of the notifier when unblocking. 

In `Scheduler::unblock` I also found the case 2b, where the thread to be woken up is searched in the ready queue, is slightly off. It incorrectly sets the current thread's status to `Ready` , which was unnecessary and misleading. Dropped it in the 4th commit. 