### PR TITLE
An attempt to solve the EINVAL problem in shm detach()

### DIFF
--- a/os/kernel/src/memory/shm.rs
+++ b/os/kernel/src/memory/shm.rs
@@ -152,13 +152,16 @@ pub fn detach(ptr:*mut u8) -> isize {
     let table = shm_tables().write();
 
     // get vma of current process for pointer (error if no vma for pointer)
-    let vma = match process.virtual_address_space.is_address_within_vma(ptr as u64, VmaType::SharedMemory { id: 0 }) {
+    let vma = match process.virtual_address_space.vma_for_address(ptr as u64) {
         Some(vma) => vma,
         None => return Errno::EINVAL.into()
     };
 
-    // get shm_id from vma (error if vma not of type shm)
-    let id = if let VmaType::SharedMemory { id} = vma.typ { id } else { return Errno::EINVAL.into(); };
+    // get shm_id from vma (error if vma is not shared memory)
+    let id = match vma.typ {
+        VmaType::SharedMemory { id } => id,
+        _ => return Errno::EINVAL.into(),
+    };
 
     // remove vma from virtual adress space of process
     process.virtual_address_space.unmap_vma(vma, false);

--- a/os/kernel/src/memory/vmm.rs
+++ b/os/kernel/src/memory/vmm.rs
@@ -582,24 +582,35 @@ impl VirtualAddressSpace {
         }
     }
 
-    /// Check if the given `address` is within a VMA of the given type `vma_type` in this address space.
-    /// Helper function using in interrupt_dispatcher.rs to check if a page fault address is within a stack or heap VMA.
-    pub fn is_address_within_vma(&self, address: u64, vma_type: VmaType) -> Option<Arc<VirtualMemoryArea>> {
+    /// Get the VMA containing the given `address`, independent of the VMA type.
+    pub fn vma_for_address(&self, address: u64) -> Option<Arc<VirtualMemoryArea>> {
         let areas = self.virtual_memory_areas.read();
-        let vaddr = VirtAddr::new(address); // or however you construct a VirtAddr from u64
+        let vaddr = VirtAddr::new(address);
 
         // Find the closest VMA with start <= address
         if let Some((_, vma)) = areas.range(..=vaddr).next_back() {
-            if vaddr < vma.end() && vma.typ == vma_type {
+            if vaddr < vma.end() {
                 return Some(Arc::clone(vma));
             }
         }
+
         None
     }
 
-    /// unmap VMA in this adress space
+    /// Check if the given `address` is within a VMA of the given type `vma_type` in this address space.
+    pub fn is_address_within_vma(&self, address: u64, vma_type: VmaType) -> Option<Arc<VirtualMemoryArea>> {
+        let vma = self.vma_for_address(address)?;
+
+        if vma.typ == vma_type {
+            Some(vma)
+        } else {
+            None
+        }
+    }
+
+    /// unmap VMA in this adress space 
     /// set free_physical to free the frames
-    pub fn unmap_vma(&self, vma: Arc<VirtualMemoryArea>, free_physical: bool) {
+    pub fn unmap_vma(&self, vma:Arc<VirtualMemoryArea>, free_physical:bool) {
         self.page_tables.unmap(vma.range, free_physical);
         self.virtual_memory_areas.write().remove(&vma.start());
     }


### PR DESCRIPTION
Add a function that doesn't check the type but only finds the VMA by address, and then let detach() determine whether it is Shared Memory itself.

The original function is no longer used in detach().